### PR TITLE
Changed haskell-build to not require a .cabal file

### DIFF
--- a/haskell-build/orb.yml
+++ b/haskell-build/orb.yml
@@ -132,19 +132,14 @@ commands:
       - run:
           name: Copying executable
           command: |
-            if [ "$BUILD_CABAL_FILE" = ""]; then
-              echo "Cannot copy binary file, as no .cabal was found, and we therefore cannot get the necessary metadata to copy the binary."
-              echo "This step can be disabled by setting 'write-result-workspace' to false."
-              exit 1
-            fi
-
             mkdir -p ./build/dist
-            _os_suffix=$OS_NAME
-            if [ "$_os_suffix" = "darwin" ]; then _os_suffix="osx"; fi
-            # according to Cabal docs executables are located here
-            _exe_build_path="$PWD/dist-newstyle/build/$BUILD_ARCH-$BUILD_OS_NAME/ghc-$BUILD_GHC_VERSION/$BUILD_PROJECT_NAME-$BUILD_PROJECT_VERSION/x/"
-            # copy all the executables
-            find "$_exe_build_path" -type f -perm -a=x -regextype egrep -regex '^.+/x/(.+)/build/\1/\1$' -exec cp -- "{}" "$PWD/build/dist" \;
+
+            # Cabal symlinks its installs, so we need to create a place for it to symlink to, and then perform a hard copy.
+            mkdir ./tmp/
+            cabal v2-install --symlink-bindir=./tmp/
+            cp -R -L ./tmp/* ./build/dist/
+            rm -rf ./tmp/
+
             ls --recursive ./build
 
   check-immediate-dependencies-coherence:

--- a/haskell-build/orb.yml
+++ b/haskell-build/orb.yml
@@ -73,7 +73,7 @@ commands:
                   # BUILD_CABAL_FILE=$((ls ${CIRCLE_PROJECT_REPONAME}.cabal || ls *.cabal || find . -type f -name '*.cabal') | head -n 1)
                   if [ "$BUILD_CABAL_FILE" = "" ]; then
                     echo "Could not find .cabal file"
-                    exit 1
+                    exit 0
                   fi
                   echo "Found $BUILD_CABAL_FILE, using it"
                   echo "export BUILD_CABAL_FILE=$BUILD_CABAL_FILE" >> $BASH_ENV
@@ -90,9 +90,13 @@ commands:
             BUILD_CABAL_VERSION=$(cabal --numeric-version)
             BUILD_GHC_VERSION=$(cat cabal.project | grep 'with-compiler:' | head -n 1 | tr -s ' ' | cut -d' ' -f2 | cut -d'-' -f2)
             if [ "$BUILD_GHC_VERSION" = "" ]; then BUILD_GHC_VERSION=$(ghc -- --numeric-version); fi
-            BUILD_PROJECT_NAME=$(cat "$BUILD_CABAL_FILE" | grep '^name:' | head -n 1 | cut -d':' -f 2 | xargs)
-            BUILD_PROJECT_VERSION=$(cat "$BUILD_CABAL_FILE" | grep -e "^version" | head -n 1 | tr -s " " | cut -d' ' -f2)
-            BUILD_EXE_NAMES=$(cat "$BUILD_CABAL_FILE" | grep 'executable ' | head -n 1 | tr -s ' ' | cut -d' ' -f2 || echo '')
+
+            if [ "$BUILD_CABAL_FILE" = ""]; then
+              BUILD_PROJECT_NAME=$(cat "$BUILD_CABAL_FILE" | grep '^name:' | head -n 1 | cut -d':' -f 2 | xargs)
+              BUILD_PROJECT_VERSION=$(cat "$BUILD_CABAL_FILE" | grep -e "^version" | head -n 1 | tr -s " " | cut -d' ' -f2)
+              BUILD_EXE_NAMES=$(cat "$BUILD_CABAL_FILE" | grep 'executable ' | head -n 1 | tr -s ' ' | cut -d' ' -f2 || echo '')
+            fi
+
             BUILD_ARCH=$(uname -m)
             BUILD_OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
             BUILD_OS_SUFFIX=$BUILD_OS_NAME
@@ -110,11 +114,14 @@ commands:
             echo "export BUILD_ARCH=$BUILD_ARCH"                       >> ./build/project.env
             echo "export BUILD_OS_NAME=$BUILD_OS_NAME"                 >> ./build/project.env
             echo "export BUILD_OS_SUFFIX=$BUILD_OS_SUFFIX"             >> ./build/project.env
-            echo "export BUILD_CABAL_FILE=$BUILD_CABAL_FILE"           >> ./build/project.env
-            echo "export BUILD_PROJECT_NAME=$BUILD_PROJECT_NAME"       >> ./build/project.env
-            echo "export BUILD_PROJECT_VERSION=$BUILD_PROJECT_VERSION" >> ./build/project.env
-            echo "export BUILD_EXE_NAMES=(${BUILD_EXE_NAMES[*]})"      >> ./build/project.env
-            echo "export BUILD_EXE_NAME=${BUILD_EXE_NAMES[0]}"         >> ./build/project.env
+
+            if [ "$BUILD_CABAL_FILE" = ""]; then
+              echo "export BUILD_CABAL_FILE=$BUILD_CABAL_FILE"           >> ./build/project.env
+              echo "export BUILD_PROJECT_NAME=$BUILD_PROJECT_NAME"       >> ./build/project.env
+              echo "export BUILD_PROJECT_VERSION=$BUILD_PROJECT_VERSION" >> ./build/project.env
+              echo "export BUILD_EXE_NAMES=(${BUILD_EXE_NAMES[*]})"      >> ./build/project.env
+              echo "export BUILD_EXE_NAME=${BUILD_EXE_NAMES[0]}"         >> ./build/project.env
+            fi
 
             cat ./build/project.env >> $BASH_ENV
             cat ./build/project.env

--- a/haskell-build/orb.yml
+++ b/haskell-build/orb.yml
@@ -132,6 +132,12 @@ commands:
       - run:
           name: Copying executable
           command: |
+            if [ "$BUILD_CABAL_FILE" = ""]; then
+              echo "Cannot copy binary file, as no .cabal was found, and we therefore cannot get the necessary metadata to copy the binary."
+              echo "This step can be disabled by setting 'write-result-workspace' to false."
+              exit 1
+            fi
+
             mkdir -p ./build/dist
             _os_suffix=$OS_NAME
             if [ "$_os_suffix" = "darwin" ]; then _os_suffix="osx"; fi

--- a/haskell-build/orb.yml
+++ b/haskell-build/orb.yml
@@ -135,10 +135,10 @@ commands:
             mkdir -p ./build/dist
 
             # Cabal symlinks its installs, so we need to create a place for it to symlink to, and then perform a hard copy.
-            mkdir ./tmp/
-            cabal v2-install --symlink-bindir=./tmp/
-            cp -R -L ./tmp/* ./build/dist/
-            rm -rf ./tmp/
+            mkdir -p ./tmp/bin/
+            cabal v2-install --symlink-bindir=./tmp/bin/
+            cp -R -L ./tmp/bin/* ./build/dist/
+            rm -rf ./tmp/bin/
 
             ls --recursive ./build
 


### PR DESCRIPTION
This adds rudimentary support for multi-project repos, which may not
have a top-level cabal file.

The Github Release Orb *does* still require one. We can fix that if/when
it becomes a problem.