### PR TITLE
MAYH-11324 remove v2-test all from orb to fix ci

### DIFF
--- a/haskell-build/orb.yml
+++ b/haskell-build/orb.yml
@@ -340,7 +340,7 @@ jobs:
                 name: Running unit tests
                 command: |
                   if cat ./build/build-info.json | jq --exit-status 'select(."component-type" == "test") | []' > /dev/null; then
-                    cabal v2-test all << parameters.cabal-test-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
+                    cabal v2-test << parameters.cabal-test-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
                   else
                     echo "No tests found"
                   fi


### PR DESCRIPTION
`cabal v2-test all` will call unit tests from libraries it depends on which we don't expect that.

`cabal v2-test` just does the test. 