### PR TITLE
Build component name and optional dependencies step

### DIFF
--- a/haskell-build/commands/build-with-binary-cache.yml
+++ b/haskell-build/commands/build-with-binary-cache.yml
@@ -6,12 +6,21 @@ parameters:
   cabal-threads:
     description: Number of Cabal threads.
     type: integer
+  build-component:
+    description: Component name to build ("all" by default)
+    type: string
   cabal-build-extra:
     description: Extra CLI parameters to pass to the "cabal v2-build" command.
     type: string
   cabal-test-extra:
     description: Extra CLI parameters to pass to the "cabal v2-test" command.
     type: string
+  build-dependencies-first:
+    description: |
+      Build project first with "--dependencies-only".
+      This is useful for making sure that dependencies are cached even if the priject doesn't compile,
+      but can get in a way in some situations.
+    type: boolean
   fail-incoherent-builds:
     description: Fail the build when immediate dependencies are incoherent
     type: boolean
@@ -115,7 +124,7 @@ steps:
   - run:
       name: Configuring project
       command: |
-        cabal v2-configure all << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG --dependencies-only -j<< parameters.cabal-threads >>
+        cabal v2-configure << parameters.build-component >> << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
 
   - when:
       name: Restore binary cache
@@ -127,39 +136,28 @@ steps:
             binary-cache-threads: << parameters.binary-cache-threads >>
             binary-cache-opts: << parameters.binary-cache-opts >>
 
-  - run:
-      command: |
-        cabal v2-build all << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG --dependencies-only -j<< parameters.cabal-threads >>
-
   - when:
-      name: Save binary cache
-      condition: << parameters.binary-cache-uri >>
+      name: Building dependencies first
+      condition: << parameters.build-dependencies-first >>
       steps:
-        - save-binary-cache:
-            binary-cache-uri: << parameters.binary-cache-uri >>
-            binary-cache-region: << parameters.binary-cache-region >>
-            binary-cache-threads: << parameters.binary-cache-threads >>
-            binary-cache-opts: << parameters.binary-cache-opts >>
+        - run:
+            name: Building dependencies
+            command: cabal v2-build << parameters.build-component >> << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG --dependencies-only -j<< parameters.cabal-threads >>
 
-  - run:
-      name: Configuring project
-      command: |
-        cabal v2-configure all << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
-
-  - when:
-      name: Restore binary cache
-      condition: << parameters.binary-cache-uri >>
-      steps:
-        - restore-binary-cache:
-            binary-cache-uri: << parameters.binary-cache-uri >>
-            binary-cache-region: << parameters.binary-cache-region >>
-            binary-cache-threads: << parameters.binary-cache-threads >>
-            binary-cache-opts: << parameters.binary-cache-opts >>
+        - when:
+            name: Save binary cache
+            condition: << parameters.binary-cache-uri >>
+            steps:
+              - save-binary-cache:
+                  binary-cache-uri: << parameters.binary-cache-uri >>
+                  binary-cache-region: << parameters.binary-cache-region >>
+                  binary-cache-threads: << parameters.binary-cache-threads >>
+                  binary-cache-opts: << parameters.binary-cache-opts >>
 
   - run:
       name: Building project
       command: |
-        cabal v2-build all << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
+        cabal v2-build << parameters.build-component >> << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
 
   - when:
       name: Save binary cache
@@ -183,7 +181,7 @@ steps:
             name: Running unit tests
             command: |
               if cat ./build/build-info.json | jq --exit-status 'select(."component-type" == "test") | []' > /dev/null; then
-                cabal v2-test all << parameters.cabal-test-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
+                cabal v2-test << parameters.build-component >> << parameters.cabal-test-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
               else
                 echo "No tests found"
               fi

--- a/haskell-build/commands/build-with-cci-cache.yml
+++ b/haskell-build/commands/build-with-cci-cache.yml
@@ -6,12 +6,21 @@ parameters:
   cabal-threads:
     description: Number of Cabal threads.
     type: integer
+  build-component:
+    description: Component name to build ("all" by default)
+    type: string
   cabal-build-extra:
     description: Extra CLI parameters to pass to the "cabal v2-build" command.
     type: string
   cabal-test-extra:
     description: Extra CLI parameters to pass to the "cabal v2-test" command.
     type: string
+  build-dependencies-first:
+    description: |
+      Build project first with "--dependencies-only".
+      This is useful for making sure that dependencies are cached even if the priject doesn't compile,
+      but can get in a way in some situations.
+    type: boolean
   fail-incoherent-builds:
     description: Fail the build when immediate dependencies are incoherent
     type: boolean
@@ -71,9 +80,21 @@ steps:
       steps:
         - check-immediate-dependencies-coherence
 
-  - run:
-      command: |
-        cabal v2-build all << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG --dependencies-only -j<< parameters.cabal-threads >>
+  - when:
+      name: Building dependencies
+      condition: << parameters.build-dependencies-first >>
+      steps:
+        - run:
+            name: Building dependencies
+            command: cabal v2-build << parameters.build-component >> << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG --dependencies-only -j<< parameters.cabal-threads >>
+
+  - unless:
+      name: Building project
+      condition: << parameters.build-dependencies-first >>
+      steps:
+        - run:
+            name: Building dependencies
+            command: cabal v2-build << parameters.build-component >> << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
 
   - save_cache:
       key: dot-cabal-{{checksum "./build/build.env"}}-{{checksum "cabal.project"}}-{{checksum "cabal.project.freeze"}}
@@ -83,10 +104,14 @@ steps:
       key: dot-cabal-{{checksum "./build/build.env"}}
       paths: [~/.cabal/packages, ~/.cabal/store]
 
-  - run:
+  - when:
       name: Building project
-      command: |
-        cabal v2-build all << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
+      condition: << parameters.build-dependencies-first >>
+      steps:
+        - run:
+            name: Building project
+            command: |
+              cabal v2-build << parameters.build-component >> << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
 
   - when:
       name: Running after-build hook steps
@@ -100,7 +125,7 @@ steps:
             name: Running unit tests
             command: |
               if cat ./build/build-info.json | jq --exit-status 'select(."component-type" == "test") | []' > /dev/null; then
-                cabal v2-test all << parameters.cabal-test-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
+                cabal v2-test << parameters.build-component >> << parameters.cabal-test-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
               else
                 echo "No tests found"
               fi

--- a/haskell-build/config.yml
+++ b/haskell-build/config.yml
@@ -138,7 +138,7 @@ jobs:
             - build-with-binary-cache:
                 cache-version:            << parameters.cache-version >>
                 cabal-threads:            << parameters.cabal-threads >>
-                build-component:    << parameters.build-component >>
+                build-component:          << parameters.build-component >>
                 cabal-build-extra:        << parameters.cabal-build-extra >>
                 cabal-test-extra:         << parameters.cabal-test-extra >>
                 build-dependencies-first: << parameters.build-dependencies-first >>
@@ -174,7 +174,7 @@ jobs:
             - build-with-cci-cache:
                 cache-version:            << parameters.cache-version >>
                 cabal-threads:            << parameters.cabal-threads >>
-                build-component:    << parameters.build-component >>
+                build-component:          << parameters.build-component >>
                 cabal-build-extra:        << parameters.cabal-build-extra >>
                 cabal-test-extra:         << parameters.cabal-test-extra >>
                 build-dependencies-first: << parameters.build-dependencies-first >>
@@ -205,7 +205,7 @@ jobs:
             - build-with-cci-cache:
                 cache-version:            << parameters.cache-version >>
                 cabal-threads:            << parameters.cabal-threads >>
-                build-component:    << parameters.build-component >>
+                build-component:          << parameters.build-component >>
                 cabal-build-extra:        << parameters.cabal-build-extra >>
                 cabal-test-extra:         << parameters.cabal-test-extra >>
                 build-dependencies-first: << parameters.build-dependencies-first >>

--- a/haskell-build/config.yml
+++ b/haskell-build/config.yml
@@ -17,6 +17,10 @@ build-params: &build-params
     description: Number of Cabal threads.
     type: integer
     default: 4
+  build-component:
+    description: Component name to build ("all" by default)
+    type: string
+    default: all
   cabal-build-extra:
     description: Extra CLI parameters to pass to the "cabal v2-build" command.
     type: string
@@ -25,6 +29,13 @@ build-params: &build-params
     description: Extra CLI parameters to pass to the "cabal v2-test" command.
     type: string
     default: ""
+  build-dependencies-first:
+    description: |
+      Build project first with "--dependencies-only".
+      This is useful for making sure that dependencies are cached even if the priject doesn't compile,
+      but can get in a way in some situations.
+    type: boolean
+    default: true
   fail-incoherent-builds:
     description: Fail the build when immediate dependencies are incoherent
     type: boolean
@@ -125,21 +136,23 @@ jobs:
 
           build-steps:
             - build-with-binary-cache:
-                cache-version:          << parameters.cache-version >>
-                cabal-threads:          << parameters.cabal-threads >>
-                cabal-build-extra:      << parameters.cabal-build-extra >>
-                cabal-test-extra:       << parameters.cabal-test-extra >>
-                fail-incoherent-builds: << parameters.fail-incoherent-builds >>
-                run-tests:              << parameters.run-tests >>
-                run-check:              << parameters.run-check >>
-                before-build:           << parameters.before-build >>
-                after-build:            << parameters.after-build >>
-                after-test:             << parameters.after-test >>
-                cabal-cache-tag:        << parameters.cabal-cache-tag >>
-                binary-cache-uri:       << parameters.binary-cache-uri >>
-                binary-cache-region:    << parameters.binary-cache-region >>
-                binary-cache-threads:   << parameters.binary-cache-threads >>
-                binary-cache-opts:      << parameters.binary-cache-opts >>
+                cache-version:            << parameters.cache-version >>
+                cabal-threads:            << parameters.cabal-threads >>
+                build-component:    << parameters.build-component >>
+                cabal-build-extra:        << parameters.cabal-build-extra >>
+                cabal-test-extra:         << parameters.cabal-test-extra >>
+                build-dependencies-first: << parameters.build-dependencies-first >>
+                fail-incoherent-builds:   << parameters.fail-incoherent-builds >>
+                run-tests:                << parameters.run-tests >>
+                run-check:                << parameters.run-check >>
+                before-build:             << parameters.before-build >>
+                after-build:              << parameters.after-build >>
+                after-test:               << parameters.after-test >>
+                cabal-cache-tag:          << parameters.cabal-cache-tag >>
+                binary-cache-uri:         << parameters.binary-cache-uri >>
+                binary-cache-region:      << parameters.binary-cache-region >>
+                binary-cache-threads:     << parameters.binary-cache-threads >>
+                binary-cache-opts:        << parameters.binary-cache-opts >>
 
   build-with-cci-cache:
     description: Build with CircleCI cache.
@@ -159,16 +172,18 @@ jobs:
 
           build-steps:
             - build-with-cci-cache:
-                cache-version:          << parameters.cache-version >>
-                cabal-threads:          << parameters.cabal-threads >>
-                cabal-build-extra:      << parameters.cabal-build-extra >>
-                cabal-test-extra:       << parameters.cabal-test-extra >>
-                fail-incoherent-builds: << parameters.fail-incoherent-builds >>
-                run-tests:              << parameters.run-tests >>
-                run-check:              << parameters.run-check >>
-                before-build:           << parameters.before-build >>
-                after-build:            << parameters.after-build >>
-                after-test:             << parameters.after-test >>
+                cache-version:            << parameters.cache-version >>
+                cabal-threads:            << parameters.cabal-threads >>
+                build-component:    << parameters.build-component >>
+                cabal-build-extra:        << parameters.cabal-build-extra >>
+                cabal-test-extra:         << parameters.cabal-test-extra >>
+                build-dependencies-first: << parameters.build-dependencies-first >>
+                fail-incoherent-builds:   << parameters.fail-incoherent-builds >>
+                run-tests:                << parameters.run-tests >>
+                run-check:                << parameters.run-check >>
+                before-build:             << parameters.before-build >>
+                after-build:              << parameters.after-build >>
+                after-test:               << parameters.after-test >>
 
   build:
     description: OBSOLETE. Use 'build-with-cci-cache'. Build with CircleCI cache.
@@ -188,13 +203,15 @@ jobs:
 
           build-steps:
             - build-with-cci-cache:
-                cache-version:          << parameters.cache-version >>
-                cabal-threads:          << parameters.cabal-threads >>
-                cabal-build-extra:      << parameters.cabal-build-extra >>
-                cabal-test-extra:       << parameters.cabal-test-extra >>
-                fail-incoherent-builds: << parameters.fail-incoherent-builds >>
-                run-tests:              << parameters.run-tests >>
-                run-check:              << parameters.run-check >>
-                before-build:           << parameters.before-build >>
-                after-build:            << parameters.after-build >>
-                after-test:             << parameters.after-test >>
+                cache-version:            << parameters.cache-version >>
+                cabal-threads:            << parameters.cabal-threads >>
+                build-component:    << parameters.build-component >>
+                cabal-build-extra:        << parameters.cabal-build-extra >>
+                cabal-test-extra:         << parameters.cabal-test-extra >>
+                build-dependencies-first: << parameters.build-dependencies-first >>
+                fail-incoherent-builds:   << parameters.fail-incoherent-builds >>
+                run-tests:                << parameters.run-tests >>
+                run-check:                << parameters.run-check >>
+                before-build:             << parameters.before-build >>
+                after-build:              << parameters.after-build >>
+                after-test:               << parameters.after-test >>


### PR DESCRIPTION
## Changes
- Make `--dependencies-only` step optional via `build-dependencies-first` flag
- Add `build-component` option setting it to `all` by default. This allows building only specified components and not the whole project.