### PR TITLE
Print component name in multi-component builds

### DIFF
--- a/haskell-build/commands/build-with-binary-cache.yml
+++ b/haskell-build/commands/build-with-binary-cache.yml
@@ -160,6 +160,7 @@ steps:
             command: |
               if << parameters.build-components-separately >>; then
                 for _component_name in << parameters.build-components >>; do
+                  echo "Building $_component_name"
                   cabal v2-build "$_component_name" << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG --dependencies-only -j<< parameters.cabal-threads >>
                 done
               else
@@ -182,6 +183,7 @@ steps:
       command: |
         if << parameters.build-components-separately >>; then
           for _component_name in << parameters.build-components >>; do
+            echo "Building $_component_name"
             cabal v2-build "$_component_name" << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
           done
         else

--- a/haskell-build/commands/build-with-cci-cache.yml
+++ b/haskell-build/commands/build-with-cci-cache.yml
@@ -93,6 +93,7 @@ steps:
             command: |
               if << parameters.build-components-separately >>; then
                 for _component_name in << parameters.build-components >>; do
+                  echo "Building $_component_name"
                   cabal v2-build "$_component_name" << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG --dependencies-only -j<< parameters.cabal-threads >>
                 done
               else
@@ -108,6 +109,7 @@ steps:
             command: |
               if << parameters.build-components-separately >>; then
                 for _component_name in << parameters.build-components >>; do
+                  echo "Building $_component_name"
                   cabal v2-build "$_component_name" << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
                 done
               else
@@ -131,6 +133,7 @@ steps:
             command: |
               if << parameters.build-components-separately >>; then
                 for _component_name in << parameters.build-components >>; do
+                  echo "Building $_component_name"
                   cabal v2-build "$_component_name" << parameters.cabal-build-extra >> $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG -j<< parameters.cabal-threads >>
                 done
               else


### PR DESCRIPTION
Example output:

```
#!/bin/bash -eo pipefail
if true; then
  for _component_name in amazonka-s3 amazonka-swf all; do
    echo "Building $_component_name"
    cabal v2-build "$_component_name"  $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG --dependencies-only -j4
  done
else
  cabal v2-build amazonka-s3 amazonka-swf all  $_BUILD_ENABLE_TESTS_FLAG $_BUILD_ENABLE_BENCHMARKS_FLAG --dependencies-only -j4
fi
Building amazonka-s3
Up to date
Building amazonka-swf
Up to date
Building all
Up to date
```