### PR TITLE
New cabal-cache-uri parameter for specifying where to download cabal …

### DIFF
--- a/haskell-build/commands/build-with-binary-cache.yml
+++ b/haskell-build/commands/build-with-binary-cache.yml
@@ -51,6 +51,10 @@ parameters:
   cabal-cache-tag:
     description: Cabal cache tag
     type: string
+  cabal-cache-uri:
+    description: Cabal cache URI.  The location of the cabal-cache binary to download.
+    type: string
+    default: ${CABAL_CACHE_URI}
   binary-cache-uri:
     description: Binary cache URI.  This may be an S3 URI.
     type: string
@@ -82,6 +86,7 @@ steps:
 
   - install-cabal-cache:
       tag:            << parameters.cabal-cache-tag >>
+      uri:            << parameters.cabal-cache-uri >>
       github-token:   << parameters.github-token >>
 
   - restore_cache:

--- a/haskell-build/commands/install-cabal-cache.yml
+++ b/haskell-build/commands/install-cabal-cache.yml
@@ -9,6 +9,11 @@ parameters:
       For list of tags see https://github.com/haskell-works/cabal-cache/tags
 
     type: string
+  uri:
+    description: |
+      Cabal cache URI.  The location of the cabal-cache binary to download.  This is optional
+
+    type: string
 steps:
   - run:
       name: Install binary cache tool (cabal-cache)
@@ -18,15 +23,22 @@ steps:
         else
           echo "Using supplied Github token"
           GITHUB_OAUTH_TOKEN_HEADER="-H 'Authorization: token <<parameters.github-token>>'"
+          eval "curl -s $GITHUB_OAUTH_TOKEN_HEADER -X GET https://api.github.com/rate_limit"
         fi
 
-        if [ "<< parameters.tag >>" = "latest" ]; then
-          curl -s --retry 3 $GITHUB_OAUTH_TOKEN_HEADER -X GET https://api.github.com/repos/haskell-works/cabal-cache/releases/latest > /tmp/releases.txt
-          CACHE_TOOL_TAG=$(curl -s --retry 3 $GITHUB_OAUTH_TOKEN_HEADER -X GET https://api.github.com/repos/haskell-works/cabal-cache/releases/latest | jq -rc .tag_name)
+        if [ "<< parameters.uri >>" = "" ]; then
+          if [ "<< parameters.tag >>" = "latest" ]; then
+            CACHE_TOOL_TAG=$(eval "curl -s $GITHUB_OAUTH_TOKEN_HEADER -X GET https://api.github.com/repos/haskell-works/cabal-cache/releases/latest" | jq -rc .tag_name)
+          else
+            CACHE_TOOL_TAG="<< parameters.tag >>"
+          fi
+
+          CACHE_TOOL_URI="https://github.com/haskell-works/cabal-cache/releases/download/${CACHE_TOOL_TAG}/cabal-cache_${BUILD_ARCH}_${BUILD_OS_NAME}.tar.gz"
         else
-          CACHE_TOOL_TAG="<< parameters.tag >>"
+          CACHE_TOOL_URI="<< parameters.uri >>"
         fi
-        echo "Downloading: https://github.com/haskell-works/cabal-cache/releases/download/${CACHE_TOOL_TAG}/cabal-cache_${BUILD_ARCH}_${BUILD_OS_NAME}.tar.gz"
-        curl -Ls https://github.com/haskell-works/cabal-cache/releases/download/${CACHE_TOOL_TAG}/cabal-cache_${BUILD_ARCH}_${BUILD_OS_NAME}.tar.gz | tar -xvz -C /tmp/
+
+        echo "Downloading: $CACHE_TOOL_URI"
+        curl -Ls "$CACHE_TOOL_URI" | tar -xvz -C /tmp/
         cp /tmp/cabal-cache /usr/local/bin/
         cabal-cache version

--- a/haskell-build/config.yml
+++ b/haskell-build/config.yml
@@ -123,6 +123,10 @@ jobs:
         description: Github tag of the 'cabal-cache' tool to use for binary caching.
         type: string
         default: latest
+      cabal-cache-uri:
+        description: Cabal cache URI.  The location of the cabal-cache binary to download.
+        type: string
+        default: ${CABAL_CACHE_URI}
       binary-cache-uri:
         description: Binary cache URI.  This may be an S3 URI.
         type: string
@@ -174,6 +178,7 @@ jobs:
                 after-test:                   << parameters.after-test >>
                 github-token:                 << parameters.github-token >>
                 cabal-cache-tag:              << parameters.cabal-cache-tag >>
+                cabal-cache-uri:              << parameters.cabal-cache-uri >>
                 binary-cache-uri:             << parameters.binary-cache-uri >>
                 binary-cache-uri-suffix:      << parameters.binary-cache-uri-suffix >>
                 binary-cache-region:          << parameters.binary-cache-region >>


### PR DESCRIPTION
…cache from.  Also fix treatment of github token when downloading the cabal cache tool.